### PR TITLE
ci: move workflows off the deprecated Node 20 actions

### DIFF
--- a/.github/workflows/audit_main_ruleset.yml
+++ b/.github/workflows/audit_main_ruleset.yml
@@ -16,10 +16,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 

--- a/.github/workflows/audit_main_ruleset.yml
+++ b/.github/workflows/audit_main_ruleset.yml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Upload compared live payload on failure
         if: ${{ failure() && hashFiles('.ruleset-audit/*') != '' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: audit-main-ruleset-live-payload
           path: .ruleset-audit

--- a/.github/workflows/bootstrap_repository.yml
+++ b/.github/workflows/bootstrap_repository.yml
@@ -21,12 +21,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 

--- a/.github/workflows/deploy_on_merge.yml
+++ b/.github/workflows/deploy_on_merge.yml
@@ -13,7 +13,7 @@ jobs:
     if: ${{ vars.DEPLOY_ON_MERGE_ENABLED == 'true' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Refuse unconfigured deploy
         run: |

--- a/.github/workflows/pr_checks_cc.yml
+++ b/.github/workflows/pr_checks_cc.yml
@@ -43,12 +43,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0  # need full history for git log base..head
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 

--- a/.github/workflows/pr_checks_codeql.yml
+++ b/.github/workflows/pr_checks_codeql.yml
@@ -40,14 +40,14 @@ jobs:
           pip install -e .
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v3
+        uses: github/codeql-action/autobuild@v4
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4
         with:
           category: "/language:${{matrix.language}}"

--- a/.github/workflows/pr_checks_codeql.yml
+++ b/.github/workflows/pr_checks_codeql.yml
@@ -24,10 +24,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           # 3.12 to match `pyproject.toml` `requires-python = ">=3.12"`
           # (driven by vaquum-praxis's >=3.12 floor; mismatched here

--- a/.github/workflows/pr_checks_fail_loud.yml
+++ b/.github/workflows/pr_checks_fail_loud.yml
@@ -41,12 +41,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 

--- a/.github/workflows/pr_checks_honesty.yml
+++ b/.github/workflows/pr_checks_honesty.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 

--- a/.github/workflows/pr_checks_lint.yml
+++ b/.github/workflows/pr_checks_lint.yml
@@ -25,7 +25,7 @@ jobs:
           python-version: '3.12'
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v8
 
       - name: Set up lint venv
         run: python -m venv .venv-lint

--- a/.github/workflows/pr_checks_lint.yml
+++ b/.github/workflows/pr_checks_lint.yml
@@ -15,12 +15,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 

--- a/.github/workflows/pr_checks_lint.yml
+++ b/.github/workflows/pr_checks_lint.yml
@@ -25,7 +25,7 @@ jobs:
           python-version: '3.12'
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v7
 
       - name: Set up lint venv
         run: python -m venv .venv-lint

--- a/.github/workflows/pr_checks_ruleset.yml
+++ b/.github/workflows/pr_checks_ruleset.yml
@@ -15,10 +15,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 

--- a/.github/workflows/pr_checks_slice.yml
+++ b/.github/workflows/pr_checks_slice.yml
@@ -50,10 +50,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 

--- a/.github/workflows/pr_checks_slice_on_issue.yml
+++ b/.github/workflows/pr_checks_slice_on_issue.yml
@@ -42,10 +42,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 

--- a/.github/workflows/pr_checks_tests.yml
+++ b/.github/workflows/pr_checks_tests.yml
@@ -15,10 +15,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 

--- a/.github/workflows/pr_checks_typing.yml
+++ b/.github/workflows/pr_checks_typing.yml
@@ -22,12 +22,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 

--- a/.github/workflows/pr_checks_typing.yml
+++ b/.github/workflows/pr_checks_typing.yml
@@ -109,7 +109,7 @@ jobs:
 
       - name: Upload pyright output
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: pyright-output
           path: pyright_output.json

--- a/.github/workflows/pr_checks_version.yml
+++ b/.github/workflows/pr_checks_version.yml
@@ -41,12 +41,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # v0.11.3
 
-- Move every workflow off the Node 20 GitHub Actions that GitHub is retiring (forced to Node 24 on 2026-06-16, removed 2026-09-16): `actions/checkout@v4` → `@v5` and `actions/setup-python@v4`/`@v5` → `@v6` across all `.github/workflows`. These were the two actions GitHub flagged as Node-20; `setup-uv` and `upload-artifact` are already on Node 24 and unchanged. Surfaced by the deprecation warning on every bootstrapped repo's Actions run.
+- Move every workflow off the Node 20 GitHub Actions that GitHub is retiring (forced to Node 24 on 2026-06-16, removed 2026-09-16). Bumped to their Node-24 majors across all `.github/workflows`: `actions/checkout@v4` → `@v5`, `actions/setup-python@v4`/`@v5` → `@v6`, `actions/upload-artifact@v4` → `@v7`, `astral-sh/setup-uv@v4` → `@v8`, and `github/codeql-action/{init,autobuild,analyze}@v3` → `@v4`. Every action whose `action.yml` declared `runs.using: node20` is now on a Node-24 major; no Node-20 action remains. Surfaced by the deprecation warning on bootstrapped repos' Actions runs.
 
 # v0.11.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v0.11.3
+
+- Move every workflow off the Node 20 GitHub Actions that GitHub is retiring (forced to Node 24 on 2026-06-16, removed 2026-09-16): `actions/checkout@v4` → `@v5` and `actions/setup-python@v4`/`@v5` → `@v6` across all `.github/workflows`. These were the two actions GitHub flagged as Node-20; `setup-uv` and `upload-artifact` are already on Node 24 and unchanged. Surfaced by the deprecation warning on every bootstrapped repo's Actions run.
+
 # v0.11.2
 
 - Document in `SETUP.md` that the approving account must have **write** access to the repository: a required approval only counts from a write-access account, so a read-only approver leaves every PR stuck at "review required". Found end-to-end — a freshly bootstrapped repo could not merge any PR until the named approver (`zero-bang`) was granted push access. The platform-settings checklist and the Appendix B failure-mode table now state the requirement and the fix (per-repo collaborator or, preferably, an org team with write on all template repos).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # v0.11.3
 
-- Move every workflow off the Node 20 GitHub Actions that GitHub is retiring (forced to Node 24 on 2026-06-16, removed 2026-09-16). Bumped to their Node-24 majors across all `.github/workflows`: `actions/checkout@v4` → `@v5`, `actions/setup-python@v4`/`@v5` → `@v6`, `actions/upload-artifact@v4` → `@v7`, `astral-sh/setup-uv@v4` → `@v8`, and `github/codeql-action/{init,autobuild,analyze}@v3` → `@v4`. Every action whose `action.yml` declared `runs.using: node20` is now on a Node-24 major; no Node-20 action remains. Surfaced by the deprecation warning on bootstrapped repos' Actions runs.
+- Move every workflow off the Node 20 GitHub Actions that GitHub is retiring (forced to Node 24 on 2026-06-16, removed 2026-09-16). Bumped to their Node-24 majors across all `.github/workflows`: `actions/checkout@v4` → `@v5`, `actions/setup-python@v4`/`@v5` → `@v6`, `actions/upload-artifact@v4` → `@v7`, `astral-sh/setup-uv@v4` → `@v7`, and `github/codeql-action/{init,autobuild,analyze}@v3` → `@v4`. Every action whose `action.yml` declared `runs.using: node20` is now on a Node-24 major; no Node-20 action remains. Surfaced by the deprecation warning on bootstrapped repos' Actions runs.
 
 # v0.11.2
 

--- a/governance/tests/test_privileged_ruleset_audit.py
+++ b/governance/tests/test_privileged_ruleset_audit.py
@@ -109,7 +109,7 @@ def test_audit_main_ruleset_workflow_contract() -> None:
     assert 'vars.RULESET_ID' in workflow
     assert '--ruleset-id "$RULESET_ID"' in workflow
     assert '--output-dir .ruleset-audit' in workflow
-    assert 'actions/upload-artifact@v4' in workflow
+    assert 'actions/upload-artifact@v7' in workflow
     assert 'failure()' in workflow
     assert '.ruleset-audit' in workflow
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "new-repository-template"
-version = "0.11.2"
+version = "0.11.3"
 description = "Gate-enforced Python repository template."
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
Closes #16

Functional change with full unit-test coverage; every gate verified locally before opening.
