### PR TITLE
fix: repair bootstrap GitHub-state reruns

### DIFF
--- a/.github/workflows/bootstrap_repository.yml
+++ b/.github/workflows/bootstrap_repository.yml
@@ -19,6 +19,7 @@ jobs:
   bootstrap:
     name: Bootstrap Repository
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -158,7 +159,7 @@ jobs:
             --body "Merge automated repository bootstrap."
 
       - name: Apply labels and protected-main ruleset
-        if: ${{ steps.bootstrap_pr.outputs.changed == 'true' }}
+        if: ${{ github.ref == 'refs/heads/main' && (steps.bootstrap_pr.outputs.changed == 'true' || github.event_name == 'workflow_dispatch') }}
         env:
           GH_TOKEN: ${{ secrets.REPO_BOOTSTRAP_TOKEN }}
           LABEL_TEMPLATE_REPOSITORY: ${{ vars.LABEL_TEMPLATE_REPOSITORY }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v0.13.2
+
+- Allow manual reruns of the bootstrap workflow from `main` to repair labels and the protected-main ruleset after file bootstrap has already merged, and bound the bootstrap job while it waits on PR checks.
+
 # v0.13.1
 
 - Consolidate the agent-facing guidelines into one canonical home each. Everything about reviewing a pull request now lives in `.github/copilot-instructions.md` (what GitHub's built-in Copilot review reads), and `CLAUDE.md` points to it for any review task instead of carrying its own copy. The generic, non-gate-enforced conventions move into `CLAUDE.md`: a new Conventions section (dependencies, logging, public surface, resources, LLM output, docs, release notes), a Fail-loud-fix-the-cause stance, and author-side PR discipline (read your own diff before requesting review; one logical change per commit). No code or gate changes.

--- a/governance/tests/test_bootstrap_workflow_contract.py
+++ b/governance/tests/test_bootstrap_workflow_contract.py
@@ -24,6 +24,23 @@ def test_bootstrap_uses_pr_path_for_protected_main() -> None:
     assert 'git push\n' not in workflow
 
 
+def test_bootstrap_github_only_repair_runs_on_manual_dispatch() -> None:
+    workflow = BOOTSTRAP_WORKFLOW.read_text(encoding='utf-8')
+    repair_condition = (
+        "github.ref == 'refs/heads/main' && "
+        "(steps.bootstrap_pr.outputs.changed == 'true' "
+        "|| github.event_name == 'workflow_dispatch')"
+    )
+
+    assert repair_condition in workflow
+
+
+def test_bootstrap_job_has_timeout() -> None:
+    workflow = BOOTSTRAP_WORKFLOW.read_text(encoding='utf-8')
+
+    assert 'timeout-minutes: 30' in workflow
+
+
 def test_bootstrap_pr_is_a_valid_slice_shape() -> None:
     workflow = BOOTSTRAP_WORKFLOW.read_text(encoding='utf-8')
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "new-repository-template"
-version = "0.13.1"
+version = "0.13.2"
 description = "Gate-enforced Python repository template."
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
Closes #29

Proof:
- `grep -Fq "github.ref == 'refs/heads/main' && (steps.bootstrap_pr.outputs.changed == 'true' || github.event_name == 'workflow_dispatch')" .github/workflows/bootstrap_repository.yml`
- `grep -Fq "timeout-minutes: 30" .github/workflows/bootstrap_repository.yml`
- `.venv/bin/python -m pytest governance/tests/test_bootstrap_workflow_contract.py governance/tests/test_version_gate.py -q`
- `.venv/bin/python -m pytest tests/package -q --maxfail=1`
- `.venv/bin/python -m pytest governance/tests/test_cc_gate.py governance/tests/test_ruleset_gate.py governance/tests/test_privileged_ruleset_audit.py governance/tests/test_ci_contract.py governance/tests/test_lint_ci_contract.py governance/tests/test_tests_ci_contract.py governance/tests/test_bootstrap_workflow_contract.py governance/tests/test_codeql_fallback.py -q`
- `.venv/bin/python governance/version_gate.py --pr-title "fix: repair bootstrap GitHub-state reruns" --base-pyproject <origin/main pyproject> --head-pyproject pyproject.toml --base-changelog <origin/main changelog> --head-changelog CHANGELOG.md`
