### PR TITLE
feat: add central governance config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v0.14.0
+
+- Add `governance.yml` as the root central governance config and enforce its first settings against the live workflows, ruleset snapshot, setup docs, review authority, and tool pins through contract tests.
+
 # v0.13.2
 
 - Allow manual reruns of the bootstrap workflow from `main` to repair labels and the protected-main ruleset after file bootstrap has already merged, and bound the bootstrap job while it waits on PR checks.

--- a/governance.yml
+++ b/governance.yml
@@ -1,0 +1,39 @@
+schema_version: 1
+
+runtime:
+  python_version: "3.12"
+
+toolchain:
+  ruff_version: "0.15.11"
+  pyright_version: "1.1.408"
+
+review:
+  approving_authority: zero-bang
+
+slice:
+  label: slice
+  issue_template: .github/ISSUE_TEMPLATE/slice.yml
+
+bootstrap:
+  timeout_minutes: 30
+  label_template_repository: Vaquum/new-repository-template
+  secrets:
+    bootstrap_token: REPO_BOOTSTRAP_TOKEN
+    ruleset_audit_token: RULESET_AUDIT_TOKEN
+  variables:
+    label_template_repository: LABEL_TEMPLATE_REPOSITORY
+    ruleset_id: RULESET_ID
+
+ruleset:
+  name: Protect-Main
+  required_status_checks:
+    - PR Checks CodeQL (python)
+    - pr_checks_cc
+    - pr_checks_lint
+    - pr_checks_ruleset
+    - pr_checks_slice
+    - pr_checks_fail_loud
+    - pr_checks_typing
+    - pr_checks_version
+    - pr_checks_tests
+    - pr_checks_honesty

--- a/governance/tests/test_governance_config.py
+++ b/governance/tests/test_governance_config.py
@@ -1,0 +1,186 @@
+from __future__ import annotations
+
+import json
+import re
+import tomllib
+from pathlib import Path
+from typing import Final
+
+import yaml
+
+REPO_ROOT: Final[Path] = Path(__file__).resolve().parents[2]
+CONFIG_PATH: Final[Path] = REPO_ROOT / 'governance.yml'
+WORKFLOWS_DIR: Final[Path] = REPO_ROOT / '.github/workflows'
+RULESET_PATH: Final[Path] = REPO_ROOT / '.github/rulesets/main.json'
+
+
+def _mapping(value: object, name: str) -> dict[str, object]:
+    assert isinstance(value, dict), f'{name} must be a mapping'
+    return {str(key): item for key, item in value.items()}
+
+
+def _config() -> dict[str, object]:
+    return _mapping(yaml.safe_load(CONFIG_PATH.read_text(encoding='utf-8')), 'governance.yml')
+
+
+def _section(name: str) -> dict[str, object]:
+    return _mapping(_config().get(name), name)
+
+
+def _str(section: dict[str, object], key: str) -> str:
+    value = section.get(key)
+    assert isinstance(value, str), f'{key} must be a string'
+    return value
+
+
+def _int(section: dict[str, object], key: str) -> int:
+    value = section.get(key)
+    assert isinstance(value, int), f'{key} must be an integer'
+    return value
+
+
+def _str_list(section: dict[str, object], key: str) -> list[str]:
+    value = section.get(key)
+    assert isinstance(value, list), f'{key} must be a list'
+    assert all(isinstance(item, str) for item in value), f'{key} must contain strings'
+    return [item for item in value if isinstance(item, str)]
+
+
+def _required_status_contexts() -> list[str]:
+    payload = json.loads(RULESET_PATH.read_text(encoding='utf-8'))
+    rules = payload['rules']
+    assert isinstance(rules, list)
+    for rule in rules:
+        rule_map = _mapping(rule, 'ruleset rule')
+        if rule_map.get('type') != 'required_status_checks':
+            continue
+        params = _mapping(rule_map.get('parameters'), 'required_status_checks parameters')
+        checks = params.get('required_status_checks')
+        assert isinstance(checks, list)
+        contexts: list[str] = []
+        for check in checks:
+            check_map = _mapping(check, 'required status check')
+            context = check_map.get('context')
+            assert isinstance(context, str)
+            contexts.append(context)
+        return contexts
+    raise AssertionError('required_status_checks rule missing from ruleset snapshot')
+
+
+def _setup_python_versions() -> dict[str, list[str]]:
+    versions: dict[str, list[str]] = {}
+    for workflow in sorted(WORKFLOWS_DIR.glob('*.yml')):
+        workflow_payload = _mapping(
+            yaml.safe_load(workflow.read_text(encoding='utf-8')), workflow.name
+        )
+        jobs = _mapping(workflow_payload.get('jobs'), f'{workflow.name}.jobs')
+        workflow_versions: list[str] = []
+        for job_name, job in jobs.items():
+            job_map = _mapping(job, f'{workflow.name}.{job_name}')
+            steps = job_map.get('steps')
+            assert isinstance(steps, list), f'{workflow.name}.{job_name}.steps must be a list'
+            for step in steps:
+                step_map = _mapping(step, f'{workflow.name}.{job_name}.step')
+                uses = step_map.get('uses')
+                if not isinstance(uses, str) or not uses.startswith('actions/setup-python@'):
+                    continue
+                with_config = _mapping(step_map.get('with'), f'{workflow.name}.{job_name}.with')
+                version = with_config.get('python-version')
+                assert isinstance(version, str), f'{workflow.name} python-version must be quoted'
+                workflow_versions.append(version)
+        if workflow_versions:
+            versions[workflow.name] = workflow_versions
+    return versions
+
+
+def _ruff_install_pins() -> dict[str, list[str]]:
+    pins: dict[str, list[str]] = {}
+    for workflow in sorted(WORKFLOWS_DIR.glob('*.yml')):
+        workflow_pins: list[str] = []
+        for line in workflow.read_text(encoding='utf-8').splitlines():
+            if 'pip install' not in line or 'ruff' not in line:
+                continue
+            matches = re.findall(r'(?<![A-Za-z0-9_-])ruff(?:==([0-9.]+))?', line)
+            assert matches, f'{workflow.name} has ruff install line without a ruff token'
+            assert all(matches), f'{workflow.name} must pin every ruff install: {line}'
+            workflow_pins.extend(matches)
+        if workflow_pins:
+            pins[workflow.name] = workflow_pins
+    return pins
+
+
+def test_governance_config_schema_is_minimal() -> None:
+    config = _config()
+
+    assert config['schema_version'] == 1
+    assert set(config) == {
+        'schema_version',
+        'runtime',
+        'toolchain',
+        'review',
+        'slice',
+        'bootstrap',
+        'ruleset',
+    }
+
+
+def test_ruleset_required_checks_match_config() -> None:
+    ruleset_config = _section('ruleset')
+    ruleset_snapshot = json.loads(RULESET_PATH.read_text(encoding='utf-8'))
+
+    assert ruleset_snapshot['name'] == _str(ruleset_config, 'name')
+    assert _required_status_contexts() == _str_list(ruleset_config, 'required_status_checks')
+
+
+def test_workflow_runtime_and_tooling_match_config() -> None:
+    runtime = _section('runtime')
+    toolchain = _section('toolchain')
+    python_version = _str(runtime, 'python_version')
+    ruff_version = _str(toolchain, 'ruff_version')
+    pyright_version = _str(toolchain, 'pyright_version')
+    pyproject = tomllib.loads((REPO_ROOT / 'pyproject.toml').read_text(encoding='utf-8'))
+
+    assert _setup_python_versions()
+    for workflow_name, versions in _setup_python_versions().items():
+        assert versions == [python_version] * len(versions), workflow_name
+    assert _ruff_install_pins()
+    for workflow_name, pins in _ruff_install_pins().items():
+        assert pins == [ruff_version] * len(pins), workflow_name
+    assert pyproject['project']['requires-python'] == f'>={python_version}'
+    assert f'ruff=={ruff_version}' in pyproject['project']['optional-dependencies']['dev']
+    assert f'pyright=={pyright_version}' in pyproject['project']['optional-dependencies']['dev']
+    assert pyproject['tool']['pyright']['pythonVersion'] == python_version
+
+
+def test_bootstrap_review_and_slice_settings_match_config() -> None:
+    bootstrap = _section('bootstrap')
+    review = _section('review')
+    slice_config = _section('slice')
+    variables = _mapping(bootstrap.get('variables'), 'bootstrap.variables')
+    secrets = _mapping(bootstrap.get('secrets'), 'bootstrap.secrets')
+    bootstrap_workflow = (WORKFLOWS_DIR / 'bootstrap_repository.yml').read_text(encoding='utf-8')
+    slice_workflow = (WORKFLOWS_DIR / 'pr_checks_slice.yml').read_text(encoding='utf-8')
+    slice_issue_workflow = (WORKFLOWS_DIR / 'pr_checks_slice_on_issue.yml').read_text(
+        encoding='utf-8'
+    )
+    label_workflow = (WORKFLOWS_DIR / 'copy-standard-labels.yml').read_text(encoding='utf-8')
+    bootstrap_script = (REPO_ROOT / 'governance/bootstrap_repository.py').read_text(
+        encoding='utf-8'
+    )
+    laws = (REPO_ROOT / 'CLAUDE.md').read_text(encoding='utf-8')
+    setup = (REPO_ROOT / 'SETUP.md').read_text(encoding='utf-8')
+    issue_template = (REPO_ROOT / _str(slice_config, 'issue_template')).read_text(encoding='utf-8')
+
+    assert f'timeout-minutes: {_int(bootstrap, "timeout_minutes")}' in bootstrap_workflow
+    assert f'--label {_str(slice_config, "label")}' in bootstrap_workflow
+    assert f'labels:\n  - {_str(slice_config, "label")}' in issue_template
+    assert _str(slice_config, 'issue_template') in slice_workflow
+    assert _str(slice_config, 'issue_template') in slice_issue_workflow
+    assert _str(bootstrap, 'label_template_repository') in bootstrap_script
+    assert _str(variables, 'label_template_repository') in bootstrap_workflow
+    assert _str(variables, 'label_template_repository') in label_workflow
+    assert _str(variables, 'ruleset_id') in setup
+    assert _str(secrets, 'bootstrap_token') in bootstrap_workflow
+    assert _str(secrets, 'ruleset_audit_token') in setup
+    assert _str(review, 'approving_authority') in laws
+    assert _str(review, 'approving_authority') in setup

--- a/governance/tests/test_lint_ci_contract.py
+++ b/governance/tests/test_lint_ci_contract.py
@@ -108,6 +108,7 @@ def test_pr_checks_lint_runs_pinned_ruff_on_tools_and_tests_tools() -> None:
     assert 'package_root="$(python - <<' in workflow
     assert '.venv-lint/bin/python -m ruff check "${{ steps.package.outputs.package_root }}" governance tests' in workflow
     assert '--source="${{ steps.package.outputs.package_root }}"' in workflow
+    assert '-m pytest tests/ governance/tests/ -q' in workflow
     assert 'continue-on-error' not in workflow
     # Hard-mechanical gate surfaces from slice #11 — each invocation
     # must appear verbatim somewhere in the workflow.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "new-repository-template"
-version = "0.13.2"
+version = "0.14.0"
 description = "Gate-enforced Python repository template."
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
Closes #32

Parent PRD: #31
Follow-up issues: #33, #34, #35

Proof:
- `test -f governance.yml`
- `.venv/bin/python -m pytest governance/tests/test_governance_config.py -q`
- `.venv/bin/python -m pytest governance/tests/test_lint_ci_contract.py governance/tests/test_tests_ci_contract.py governance/tests/test_bootstrap_workflow_contract.py -q`
- `.venv/bin/python -m pytest tests/ governance/tests/ -q`
- `.venv/bin/python governance/check_module_budgets.py`
- `.venv/bin/python governance/check_module_docstrings.py`
- `.venv/bin/python governance/check_file_size_balance.py`
- `.venv/bin/python governance/check_test_code_ratio.py`
- `.venv/bin/python governance/check_test_fallbacks.py`
- `.venv/bin/python governance/check_no_swallowed_violations.py`
- `.venv/bin/python governance/version_gate.py --pr-title "feat: add central governance config" --base-pyproject <origin/main pyproject> --head-pyproject pyproject.toml --base-changelog <origin/main changelog> --head-changelog CHANGELOG.md`
- `.venv/bin/python -m pytest tests/package -q --maxfail=1`

Review:
- Codex CLI: no blocking findings after reviewer fixes.
- Claude CLI: no findings after reviewer fixes.
